### PR TITLE
Reformat README, closes #44 and #45

### DIFF
--- a/1.16when/index.html
+++ b/1.16when/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!-- This is bigrat.monster. Welcome. -->
 <!-- FOR MORE INFORMATION, PLEASE VISIT https://github.com/bigratmonster/bigrat.monster -->
 <html>

--- a/404.html
+++ b/404.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!-- This is bigrat.monster. Welcome. -->
 <!-- FOR MORE INFORMATION, PLEASE VISIT https://github.com/bigratmonster/bigrat.monster -->
 <html>

--- a/facts/index.html
+++ b/facts/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <meta http-equiv="refresh" content="5; url=https://docs.google.com/document/d/1q04ryP_d-smtSSwXkDATFQd-4UcQBlgpfWULdvLgh2M">
     <body>

--- a/freekr/index.html
+++ b/freekr/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
         <title>Free KR</title>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!-- This is bigrat.monster. Welcome. -->
 <!-- FOR MORE INFORMATION, PLEASE VISIT https://github.com/bigratmonster/bigrat.monster -->
 <html>

--- a/printer/index.html
+++ b/printer/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!-- This is bigrat.monster. Welcome. -->
 <!-- FOR MORE INFORMATION, PLEASE VISIT https://github.com/bigratmonster/bigrat.monster -->
 <html>

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 a picture of big rat
 
-## Copyright Information
+### Copyright Information
 
 **If you are the owner or the copyright holder of the [big rat] image, please [contact me][email-copyright].**  
 I would like to have your approval for us to coutinue to host your image.
@@ -10,7 +10,7 @@ I would like to have your approval for us to coutinue to host your image.
 If you would like to remove content due to copyright reasons, please don't submit a DMCA 😢  
 Please [contact me][email-copyright] or open an [issue] (select "Copyright issue" when choosing templates) and I'll sort this out.
 
-## Host this website yourself
+### Host this website yourself
 
 Please follow the instructions in [usage.md].
 
@@ -25,86 +25,84 @@ Please [contact them][email-skrub] for any content removals.
 
 ## By the repository owner
 
-### Big Rat
-
+#### [Big Rat](media/bigrat.png)
 > Attempts have been made to find the copyright owner, but no result has been found.
 If you are the original author or copyright holder, please [contact me][email-copyright].
 
 ## By a contributor
-
 *The description of the images below are written by the uploader.*
 
-### Garpub
+#### [Garpub](media/garpub.gif)
 
 *by [humboldt123]*  
 From the Garfield show
 
-### Holyc
+#### [Holyc](media/holyc.gif)
 
 *by [humboldt123]*  
 Terry a davis just jiving and grooving
 
-### Ratpog
+#### [Ratpog](media/ratpog.jpg)
 
 *by [humboldt123]*  
 Cant find source owo
 
-### Widecatflushed
+#### [Widecatflushed](media/widecatflushed.png)
 
 *by [humboldt123]*  
 An edit of the cat/flushed twitter emoji
 
-### Yandev and Umad
+#### [Yandev](media/yandev.gif) and [Umad](media/umad.gif)
 
 *by [humboldt123]*  
 Both the likeness of YandereDev
 
-### Noanime and elhuevo
+#### [Noanime](media/noanime.gif) and [elhuevo](media/elheuvo.gif) <!-- Yes, the filename is spelt wrong in the repo -->
 
 *by [humboldt123]*  
 Cant find source owo
 
-### Rat Equality
+#### [Rat Equality](media/ratequality.png)
 
 *by [luciel]*  
 epic edit made by undead luciel
 
-### Rat Rights
+#### [Rat Rights](media/ratrights.png)
 
 *by [luciel]*  
 :3 made by undead luciel
 
-### unknown.png
+#### [unknown.png](media/unknown.png)
 
 *by [humboldt123]*  
 An image of [Brady] saying that (someone that shall not be named)'s opinion doesnt matter on Discord
 
-### telegram_video
+#### [telegram_video](media/telegram-video.mp4)
 
 *by [humboldt123]*  
 a speech of soviet dictator joseph stalin
 
-### dream_chungus
+#### [dream_chungus](media/dream_chungus.png)
 
 *by [bigratenthusiast]*
 An image of big chungus with dreams face
 
-### deepfakes/ folder
+#### [deepfakes/](media/deepfakes/) folder
 
 *by [humboldt123]*  
 deepfakes by skrub using [first order model]
 
-### cleanrat
+#### [cleanrat](media/cleanrat.gif)
 
 *by [humboldt123]*  
 from tenor: <https://tenor.com/view/rat-shower-time-take-abath-get-wet-gif-17954470>
 
-### monkeys/ Folder
+#### [monkeys/](media/monkeys/) Folder
 
 *by [humboldt123]*  
 All of the gifs can be found on Tenor with the exception of the video which is found on Imgur
 
-### printer
+#### [printer](printer/printer.html)
 
 *by [smokeytube]*  
 inside joke??? Idfk??
@@ -124,7 +122,7 @@ https://tenor.com/view/monkey-with-money-happy-withmoney-swag-dollars-more-money
 https://cdn.discordapp.com/attachments/537457343622021131/736039744206798928/Monkey_Orange.gif
 ```
 
-### trollcrazy
+#### [trollcrazy](media/trollcrazy.png)
 
 *by [bigratenthusiast]*
 Original creator unknown, if thats you please reach out


### PR DESCRIPTION
- README headings have been selectively adjusted to appear more visually consistent. (Probably?) closes #45.
- Relative links have been added to README that reference the image and video assets being credited (inside the repo), allowing for easier navigation and disambiguation (as some of the filenames don't match up directly).
- DOCTYPE has been added to all applicable HTML files. They should no longer render like Netscape pages (though this has no functional difference yet due to the simplicity of the documents). Closes #44.